### PR TITLE
Update .gitmodules to fix `forge install`

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,7 +3,7 @@
 	url = https://github.com/foundry-rs/forge-std
 [submodule "lib/account-abstraction"]
 	path = lib/account-abstraction
-	url = git@github.com:eth-infinitism/account-abstraction.git
+	url = https://github.com/eth-infinitism/account-abstraction
 [submodule "lib/erc6551"]
 	path = lib/erc6551
 	url = https://github.com/erc6551/reference


### PR DESCRIPTION
forge install is currently broken
use https instead of ssh